### PR TITLE
Fix shelf tabs redirecting to remote instance for remote users

### DIFF
--- a/bookwyrm/templates/shelf/shelf.html
+++ b/bookwyrm/templates/shelf/shelf.html
@@ -49,7 +49,7 @@
                 {% for shelf_tab in shelves %}
                 <li class="{% if shelf_tab.identifier == shelf.identifier %}is-active{% endif %}">
                     <a
-                        href="{% url 'shelf' user|username shelf_tab.identifier %}"
+                        href="/user/{{ user|username }}/books/{{ shelf_tab.identifier }}"
                         {% if shelf_tab.identifier == shelf.identifier %} aria-current="page"{% endif %}
                     >
                         {% include "snippets/translated_shelf_name.html" with shelf=shelf_tab %}

--- a/bookwyrm/templates/shelf/shelf.html
+++ b/bookwyrm/templates/shelf/shelf.html
@@ -49,7 +49,7 @@
                 {% for shelf_tab in shelves %}
                 <li class="{% if shelf_tab.identifier == shelf.identifier %}is-active{% endif %}">
                     <a
-                        href="{{ shelf_tab.local_path }}"
+                        href="{% url 'shelf' user|username shelf_tab.identifier %}"
                         {% if shelf_tab.identifier == shelf.identifier %} aria-current="page"{% endif %}
                     >
                         {% include "snippets/translated_shelf_name.html" with shelf=shelf_tab %}

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -48,7 +48,7 @@
                 {% elif shelf.name == 'Read' %}{% trans "Read" %}
                 {% elif shelf.name == 'Stopped Reading' %}{% trans "Stopped Reading" %}
                 {% else %}{{ shelf.name }}{% endif %}
-                {% if shelf.size > 4 %}<small>(<a href="{% url 'shelf' user|username shelf.identifier %}">{% blocktrans with size=shelf.size %}View all {{ size }}{% endblocktrans %}</a>)</small>{% endif %}
+                {% if shelf.size > 4 %}<small>(<a href="/user/{{ user|username }}/books/{{ shelf.identifier }}">{% blocktrans with size=shelf.size %}View all {{ size }}{% endblocktrans %}</a>)</small>{% endif %}
             </h3>
             <div class="is-mobile field is-grouped">
             {% for book in shelf.books %}

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -48,7 +48,7 @@
                 {% elif shelf.name == 'Read' %}{% trans "Read" %}
                 {% elif shelf.name == 'Stopped Reading' %}{% trans "Stopped Reading" %}
                 {% else %}{{ shelf.name }}{% endif %}
-                {% if shelf.size > 4 %}<small>(<a href="{{ shelf.local_path }}">{% blocktrans with size=shelf.size %}View all {{ size }}{% endblocktrans %}</a>)</small>{% endif %}
+                {% if shelf.size > 4 %}<small>(<a href="{% url 'shelf' user|username shelf.identifier %}">{% blocktrans with size=shelf.size %}View all {{ size }}{% endblocktrans %}</a>)</small>{% endif %}
             </h3>
             <div class="is-mobile field is-grouped">
             {% for book in shelf.books %}

--- a/bookwyrm/tests/views/test_user.py
+++ b/bookwyrm/tests/views/test_user.py
@@ -155,6 +155,66 @@ class UserViews(TestCase):
 
         self.assertEqual(first_book, self.book_recently_shelved)
 
+    def test_user_page_shelf_preview_has_identifier(self):
+        """shelf preview should include identifier for generating local URLs"""
+        view = views.User.as_view()
+        request = self.factory.get("")
+        request.user = self.local_user
+        with patch("bookwyrm.views.user.is_api_request") as is_api:
+            is_api.return_value = False
+            result = view(request, "mouse")
+
+        self.assertIsInstance(result, TemplateResponse)
+        self.assertEqual(result.status_code, 200)
+
+        # Verify shelf preview has 'identifier' key (used for URL generation)
+        # and does NOT have 'local_path' key (which would redirect remote users)
+        first_shelf = result.context_data["shelves"][0]
+        self.assertIn("identifier", first_shelf)
+        self.assertNotIn("local_path", first_shelf)
+        self.assertEqual(first_shelf["identifier"], "to-read")
+
+    def test_user_page_remote_user_shelf_preview(self):
+        """viewing remote user should have shelf identifiers for local URLs"""
+        with patch("bookwyrm.models.user.set_remote_server"):
+            remote_user = models.User.objects.create_user(
+                "nutria",
+                "",
+                "nutriaword",
+                local=False,
+                remote_id="https://example.com/users/nutria",
+                inbox="https://example.com/users/nutria/inbox",
+                outbox="https://example.com/users/nutria/outbox",
+            )
+        # Create a shelf for the remote user (remote users don't get default shelves)
+        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
+            shelf = models.Shelf.objects.create(
+                name="To Read",
+                identifier="to-read",
+                user=remote_user,
+            )
+            models.ShelfBook.objects.create(
+                book=self.book,
+                user=remote_user,
+                shelf=shelf,
+            )
+
+        view = views.User.as_view()
+        request = self.factory.get("")
+        request.user = self.local_user
+        with patch("bookwyrm.views.user.is_api_request") as is_api:
+            is_api.return_value = False
+            result = view(request, "nutria@example.com")
+
+        self.assertIsInstance(result, TemplateResponse)
+        self.assertEqual(result.status_code, 200)
+
+        # Verify shelf preview uses identifier (not local_path which would be remote URL)
+        if result.context_data["shelves"]:
+            first_shelf = result.context_data["shelves"][0]
+            self.assertIn("identifier", first_shelf)
+            self.assertNotIn("local_path", first_shelf)
+
     def test_followers_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Relationships.as_view()

--- a/bookwyrm/views/user.py
+++ b/bookwyrm/views/user.py
@@ -56,7 +56,7 @@ class User(View):
             shelf_preview.append(
                 {
                     "name": user_shelf.name,
-                    "local_path": user_shelf.local_path,
+                    "identifier": user_shelf.identifier,
                     "books": user_shelf.books.order_by(
                         "-shelfbook__shelved_date"
                     ).all()[:3],


### PR DESCRIPTION
## Description
  Shelf tabs when viewing a remote user's profile were incorrectly redirecting to the remote instance instead of showing the shelf on the local instance. This fixes the URL construction to use direct paths.

  - Related Issue #
  - Closes #3685

  ## What type of Pull Request is this?

  - [x] Bug Fix
  - [ ] Enhancement
  - [ ] Plumbing / Internals / Dependencies
  - [ ] Refactor

  ## Does this PR change settings or dependencies, or break something?

  - [ ] This PR changes or adds default settings, configuration, or .env values
  - [ ] This PR changes or adds dependencies
  - [ ] This PR introduces other breaking changes

  ### Details of breaking or configuration changes (if any of above checked)


  ## Documentation

  - [ ] New or amended documentation will be required if this PR is merged
  - [ ] I have created a matching pull request in the Documentation repository
  - [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

  ### Tests

  - [ ] My changes do not need new tests
  - [ ] All tests I have added are passing
  - [x] I have written tests but need help to make them pass
  - [ ] I have not written tests and need help to write them