### PR TITLE
Fix ratings hidden for unauthenticated users

### DIFF
--- a/bookwyrm/templates/snippets/stars.html
+++ b/bookwyrm/templates/snippets/stars.html
@@ -7,7 +7,7 @@
 
     {% if rating %}
 
-        {% if not request.user.show_ratings %}
+        {% if request.user.is_authenticated and not request.user.show_ratings %}
 
         <button type="button" data-controls="rating-{{ uuid }}" id="rating-button-{{ uuid }}" aria-pressed="false" data-disappear>
             <em>{% trans "Show rating" %} </em>
@@ -15,7 +15,7 @@
 
         {% endif %}
 
-        <span class="{% if not request.user.show_ratings %}is-hidden{% endif %}" id="rating-{{ uuid }}">
+        <span class="{% if request.user.is_authenticated and not request.user.show_ratings %}is-hidden{% endif %}" id="rating-{{ uuid }}">
             <span class="is-sr-only">
                 {% blocktranslate trimmed with rating=rating|floatformat:0 count counter=rating|floatformat:0|add:0 %}
                     {{ rating }} star


### PR DESCRIPTION
## Description
  Anonymous users were seeing a "Show rating" button instead of the actual star rating. The template checked `request.user.show_ratings` without first verifying the user is authenticated, causing the condition to fail for anonymous users.

  Now checks `is_authenticated` first, so anonymous users see ratings by default (matching expected behavior).

  - Related Issue #
  - Closes #3720

  ## What type of Pull Request is this?

  - [x] Bug Fix
  - [ ] Enhancement
  - [ ] Plumbing / Internals / Dependencies
  - [ ] Refactor

  ## Does this PR change settings or dependencies, or break something?

  - [ ] This PR changes or adds default settings, configuration, or .env values
  - [ ] This PR changes or adds dependencies
  - [ ] This PR introduces other breaking changes

  ### Details of breaking or configuration changes (if any of above checked)


  ## Documentation

  - [ ] New or amended documentation will be required if this PR is merged
  - [ ] I have created a matching pull request in the Documentation repository
  - [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

  ### Tests

  - [x] My changes do not need new tests
  - [ ] All tests I have added are passing
  - [ ] I have written tests but need help to make them pass
  - [ ] I have not written tests and need help to write them