### PR TITLE
Fix ISBN hyphenation ValueError for empty/short strings

### DIFF
--- a/bookwyrm/isbn/isbn.py
+++ b/bookwyrm/isbn/isbn.py
@@ -37,6 +37,10 @@ class IsbnHyphenator:
         if isbn_13 is None:
             return None
 
+        # Handle empty string or invalid length ISBN
+        if not isbn_13 or len(isbn_13) < 13:
+            return isbn_13
+
         if self.__element_tree is None:
             self.__element_tree = ElementTree.parse(self.__range_file_path)
 


### PR DESCRIPTION
## Description
  The ISBN hyphenation function was raising a `ValueError` when passed empty or very short ISBN strings. Added defensive checks to handle edge cases gracefully.

  - Related Issue #
  - Closes #

  ## What type of Pull Request is this?

  - [x] Bug Fix
  - [ ] Enhancement
  - [ ] Plumbing / Internals / Dependencies
  - [ ] Refactor

  ## Does this PR change settings or dependencies, or break something?

  - [ ] This PR changes or adds default settings, configuration, or .env values
  - [ ] This PR changes or adds dependencies
  - [ ] This PR introduces other breaking changes

  ### Details of breaking or configuration changes (if any of above checked)


  ## Documentation

  - [ ] New or amended documentation will be required if this PR is merged
  - [ ] I have created a matching pull request in the Documentation repository
  - [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

  ### Tests

  - [x] My changes do not need new tests
  - [ ] All tests I have added are passing
  - [ ] I have written tests but need help to make them pass
  - [ ] I have not written tests and need help to write them